### PR TITLE
run e2e tests on push

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -2,6 +2,10 @@ name: Pull Request Checks
 
 on: [pull_request]
 
+env:
+  # WDIO env variable since we run on ubuntu-latest
+  PLATFORM_NAME: linux
+
 jobs:
     execute-pr-checks:
         runs-on: ubuntu-latest
@@ -12,6 +16,8 @@ jobs:
         steps:
             - name: checkout repo
               uses: actions/checkout@v4
+              with:
+                path: e2e-tests
 
             - name: setup Node.js
               uses: actions/setup-node@v4
@@ -20,6 +26,64 @@ jobs:
 
             - name: install dependencies
               run: npm ci
+              working-directory: e2e-tests
 
             - name: run linting for project source
               run: npm run lint
+              working-directory: e2e-tests
+
+            - name: checkout Angular app UI
+              uses: actions/checkout@v4
+              with:
+                repository: antonborisoff/contracts-angular
+                path: contracts-angular
+            
+            - name: install Angular app UI dependencies
+              run: npm ci
+              working-directory: contracts-angular
+
+            - name: run Angular app UI
+              uses: JarvusInnovations/background-action@v1
+              with:
+                run: npm run start &
+                # the host and port Angular local development server runs at by default
+                wait-on: http://localhost:4200
+                tail: true
+                log-output-resume: stderr
+                wait-for: 15s
+                log-output: stderr,stdout
+                log-output-if: failure
+                working-directory: contracts-angular
+
+            - name: checkout app backend
+              uses: actions/checkout@v4
+              with:
+                repository: antonborisoff/contracts-backend
+                path: contracts-backend
+
+            - name: install app backend dependencies
+              run: npm ci
+              working-directory: contracts-backend
+            
+            - name: run app backend
+              uses: JarvusInnovations/background-action@v1
+              with:
+                run: npm run server &
+                # host and port express server runs at by default; API is designed to check the server status
+                wait-on: http://localhost:9000/status
+                tail: true
+                log-output-resume: stderr
+                wait-for: 15s
+                log-output: stderr,stdout
+                log-output-if: failure
+                working-directory: contracts-backend
+
+            - name: run e2e tests against the app
+              run: npm run wdio:github-actions
+              working-directory: e2e-tests
+
+            - uses: actions/upload-artifact@v4
+              with:
+                name: wdio-logs
+                # this is the folder specified in wdio.conf.ts
+                path: e2e-tests/wdio-logs/

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@wdio/jasmine-framework": "^8.34.1",
         "@wdio/local-runner": "^8.34.1",
         "@wdio/spec-reporter": "^8.32.4",
+        "deepmerge": "^4.3.1",
         "eslint-plugin-import-newlines": "^1.3.4",
         "eslint-plugin-jasmine": "^4.1.3",
         "ts-node": "^10.9.2",
@@ -3484,6 +3485,15 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "peer": true
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/deepmerge-ts": {
       "version": "5.1.0",

--- a/package.json
+++ b/package.json
@@ -11,15 +11,17 @@
     "@wdio/jasmine-framework": "^8.34.1",
     "@wdio/local-runner": "^8.34.1",
     "@wdio/spec-reporter": "^8.32.4",
+    "deepmerge": "^4.3.1",
     "eslint-plugin-import-newlines": "^1.3.4",
     "eslint-plugin-jasmine": "^4.1.3",
     "ts-node": "^10.9.2",
     "typescript": "^5.4.2"
   },
   "scripts": {
-    "lint": "eslint ./test",
+    "lint": "eslint ./test wdio*.conf.ts",
     "lint:fix": "npm run lint -- --fix",
-    "wdio": "wdio run ./wdio.conf.ts"
+    "wdio": "wdio run ./wdio.conf.ts",
+    "wdio:github-actions": "wdio run ./wdio_github_actions.conf.ts"
   },
   "dependencies": {
     "@angular/cdk": "^17.3.0",

--- a/wdio_github_actions.conf.ts
+++ b/wdio_github_actions.conf.ts
@@ -1,0 +1,23 @@
+import {
+  Capabilities
+} from '@wdio/types'
+
+import deepmerge from 'deepmerge'
+import {
+  config as baseConfig
+} from './wdio.conf.js'
+
+const githubActionsConfig = deepmerge({}, baseConfig, {
+  arrayMerge: (destinationArray, sourceArray) => sourceArray,
+  clone: false
+})
+
+const newCapabilities = baseConfig.capabilities as Capabilities.BrowserStackCapabilities[]
+newCapabilities.forEach((capability) => {
+  if (capability.browserName === 'chrome') {
+    // required for runners used by GitHub Actions
+    capability['goog:chromeOptions'].args.push('--headless=new')
+  }
+})
+
+export const config = githubActionsConfig


### PR DESCRIPTION
Configure e2e test execution on push against the app:
1) use JarvusInnovations/background-action@v1 to start local Angular UI and backend servers and wait until they are up;
2) create WDIO config for GitHub Actions runners (use Linux as platform and run Chrome in headless mode);
3) upload WDIO logs as artifacts to the checks run so that it is possible to debug if necessary;